### PR TITLE
Feat: Implement `parseMarkdownFrontmatter`

### DIFF
--- a/__tests__/parseMarkdownFrontmatter.test.ts
+++ b/__tests__/parseMarkdownFrontmatter.test.ts
@@ -1,0 +1,246 @@
+// __tests__/parseMarkdownFrontmatter.test.ts
+
+import Ajv, { ErrorObject } from "ajv";
+import { formatValidationError, parseMarkdownFrontmatter } from "../utils/parseMarkdownFrontmatter";
+
+describe("formatValidationError", () => {
+    test("Show default error message for an unknown keyword", () => {
+        const fakeError: ErrorObject = {
+            instancePath: '/example',
+            message: 'has an error',
+            keyword: 'unknownKeyword',
+            params: {},
+            schemaPath: '',
+        };
+    
+        const result = formatValidationError(fakeError);
+        expect(result).toMatch(/ \(Keyword: unknownKeyword\)$/);
+    });
+});
+
+
+describe("parseMarkdownFrontmatter", () => {
+
+    const minimalValidFrontmatter = {
+        title: "Test Title",
+        date: "2025-02-18",
+        authors: ["jathurchan"],
+    };
+
+    const fullValidFrontmatter = {
+        title: "Test Title",
+        intro: "Test Introduction",
+        allowTitleToDifferFromFilename: true,
+        date: "2025-02-18",
+        authors: ["jathurchan", "mathusanm6"],
+        featuredVideo: "https://youtu.be/sOmeViDeO",
+        projects: ["projectId"],
+        skills: ["skillId"],
+        includeLinks: ["/some/link"],
+        showRelatedPRs: false,
+    };
+
+    // ==== Several simulataneous Errors ====
+
+    test("Fail when multiple errors are present", () => {
+        const data = {}; // Missing title, date, and authors
+        try {
+            parseMarkdownFrontmatter(data);
+            throw new Error("Expected parseMarkdownFrontmatter to throw an error.");
+        } catch (error: any) {
+            expect(error.message).toMatch(/Missing required field 'title'/);
+            expect(error.message).toMatch(/Missing required field 'date'/);
+            expect(error.message).toMatch(/Missing required field 'authors'/);
+        }
+    });
+
+    // ==== Valid Frontmatter ====
+
+    test("Parse valid frontmatter with only required fields", () => {
+        const result = parseMarkdownFrontmatter({ ...minimalValidFrontmatter });
+        expect(result.title).toBe(minimalValidFrontmatter.title);
+        expect(result.date).toEqual(new Date(minimalValidFrontmatter.date));
+        expect(result.authors).toEqual(minimalValidFrontmatter.authors);
+        // Optional fields should have their defaults:
+        expect(result.intro).toBeUndefined();
+        expect(result.allowTitleToDifferFromFilename).toBe(false);
+        expect(result.featuredVideo).toBeUndefined();
+        expect(result.projects).toEqual([]);
+        expect(result.skills).toEqual([]);
+        expect(result.includeLinks).toEqual([]);
+        expect(result.showRelatedPRs).toBe(true);
+    });
+
+    test("Parse valid frontmatter with all fields", () => {
+        const result = parseMarkdownFrontmatter({ ...fullValidFrontmatter });
+        expect(result.title).toBe(fullValidFrontmatter.title);
+        expect(result.intro).toBe(fullValidFrontmatter.intro);
+        expect(result.allowTitleToDifferFromFilename).toBe(
+        fullValidFrontmatter.allowTitleToDifferFromFilename
+        );
+        expect(result.date).toEqual(new Date(fullValidFrontmatter.date));
+        expect(result.authors).toEqual(fullValidFrontmatter.authors);
+        expect(result.featuredVideo?.toString()).toBe(fullValidFrontmatter.featuredVideo);
+        expect(result.projects).toEqual(fullValidFrontmatter.projects);
+        expect(result.skills).toEqual(fullValidFrontmatter.skills);
+        expect(result.includeLinks).toEqual(fullValidFrontmatter.includeLinks);
+        expect(result.showRelatedPRs).toBe(fullValidFrontmatter.showRelatedPRs);
+    });
+
+    // ==== Required Fields ====
+
+    test("Fail when title is missing", () => {
+        const data = { date: "2025-02-18", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Missing required field 'title'/
+        );
+    });
+
+    test("Fail when date is missing", () => {
+        const data = { title: "Test Title", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Missing required field 'date'/
+        );
+    });
+
+    test("Fail when authors is missing", () => {
+        const data = { title: "Test Title", date: "2025-02-18" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Missing required field 'authors'/
+        );
+    });
+
+    test("Fail when title is not a string", () => {
+        const data = { title: 123, date: "2025-02-18", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when date is not a string", () => {
+        const data = { title: "Test Title", date: 20230101, authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when date is not a valid date string", () => {
+        const data = { title: "Test Title", date: "invalid-date", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Invalid format 'date'/
+        );
+    });
+
+    test("Fail when authors is not an array", () => {
+        const data = { title: "Test Title", date: "2025-02-18", authors: "jathurchan" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'array'/
+        );
+    });
+
+    test("Fail when authors is empty", () => {
+        const data = { title: "Test Title", date: "2025-02-18", authors: [] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Array must have at least/
+        );
+    });
+
+    test("Fail when authors contains non-string elements", () => {
+        const data = { title: "Test Title", date: "2025-02-18", authors: [123] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    // ==== Unexpected Fields ====
+
+    test("Fail when additional field is present", () => {
+        const data = {
+            ...minimalValidFrontmatter,
+            unexpectedField: "not allowed",
+        };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Unexpected field 'unexpectedField'/
+        );
+    });
+
+    // ==== Optional Fields ====
+
+    test("Fail when intro is present and not a string", () => {
+        const data = { ...minimalValidFrontmatter, intro: 123 };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when allowTitleToDifferFromFilename is present and not a boolean", () => {
+        const data = { ...minimalValidFrontmatter, allowTitleToDifferFromFilename: "yes" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'boolean'/
+        );
+    });
+
+    test("Fail when featuredVideo is not a string", () => {
+        const data = { ...minimalValidFrontmatter, featuredVideo: 12345 };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when featuredVideo is not a valid url string", () => {
+        const data = { ...minimalValidFrontmatter, featuredVideo: "not-a-url" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Invalid format 'uri'/
+        );
+    });
+
+    test("Fail when projects is not an array", () => {
+        const data = { ...minimalValidFrontmatter, projects: "project1" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'array'/
+        );
+    });
+
+    test("Fail when projects contains non-string elements", () => {
+        const data = { ...minimalValidFrontmatter, projects: [123] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    
+    test("Fail when skills is not an array", () => {
+        const data = { ...minimalValidFrontmatter, skills: "skill1" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'array'/
+        );
+    });
+
+    test("Fail when skills contains non-string elements", () => {
+        const data = { ...minimalValidFrontmatter, skills: [123] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when includeLinks is not an array", () => {
+        const data = { ...minimalValidFrontmatter, includeLinks: "link" };
+    expect(() => parseMarkdownFrontmatter(data)).toThrow(
+        /Expected type 'array'/
+    );
+    });
+
+    test("Fail when includeLinks contains non-string elements", () => {
+        const data = { ...minimalValidFrontmatter, includeLinks: [123] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'string'/
+        );
+    });
+
+    test("Fail when showRelatedPRs is not a boolean", () => {
+        const data = { ...minimalValidFrontmatter, showRelatedPRs: "yes" };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /Expected type 'boolean'/
+        );
+    });
+});

--- a/__tests__/parseMarkdownFrontmatter.test.ts
+++ b/__tests__/parseMarkdownFrontmatter.test.ts
@@ -101,7 +101,7 @@ describe("parseMarkdownFrontmatter", () => {
         expect(() => parseMarkdownFrontmatter(data)).toThrow(
             /Missing required field 'date'/
         );
-    });
+    }); 
 
     test("Fail when authors is missing", () => {
         const data = { title: "Test Title", date: "2025-02-18" };
@@ -114,6 +114,20 @@ describe("parseMarkdownFrontmatter", () => {
         const data = { title: 123, date: "2025-02-18", authors: ["jathurchan"] };
         expect(() => parseMarkdownFrontmatter(data)).toThrow(
             /Expected type 'string'/
+        );
+    });
+
+    test("Fail when title is an empty string", () => {
+        const data = { title: "", date: "2025-02-18", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /title.*cannot be empty/
+        );
+    });
+
+    test("Fail when title contains only whitespace", () => {
+        const data = { title: "   ", date: "2025-02-18", authors: ["jathurchan"] };
+        expect(() => parseMarkdownFrontmatter(data)).toThrow(
+            /title.*cannot.*contain only whitespace/
         );
     });
 

--- a/__tests__/parseMarkdownFrontmatter.test.ts
+++ b/__tests__/parseMarkdownFrontmatter.test.ts
@@ -1,7 +1,7 @@
 // __tests__/parseMarkdownFrontmatter.test.ts
 
-import Ajv, { ErrorObject } from "ajv";
-import { formatValidationError, parseMarkdownFrontmatter } from "../utils/parseMarkdownFrontmatter";
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
+import { formatValidationError, getValidationErrors, parseMarkdownFrontmatter } from "../utils/parseMarkdownFrontmatter";
 
 describe("formatValidationError", () => {
     test("Show default error message for an unknown keyword", () => {
@@ -18,6 +18,16 @@ describe("formatValidationError", () => {
     });
 });
 
+describe("getValidationErrors", () => {
+    test("Handle validateFrontmatter.errors undefined", () => {
+        const fakeValidator = {
+            errors: undefined
+        } as ValidateFunction;
+    
+        const result = getValidationErrors(fakeValidator);
+        expect(result).toEqual([]);
+    });
+});
 
 describe("parseMarkdownFrontmatter", () => {
 

--- a/content/design-documents/2025-02-18-markdown-frontmatter-validator.md
+++ b/content/design-documents/2025-02-18-markdown-frontmatter-validator.md
@@ -1,0 +1,81 @@
+---
+title: "Markdown Frontmatter Validator"
+date: "2025-02-18"
+authors:
+  - "jathurchan"
+projects:
+  - "63"
+  - "102"
+---
+
+## Background
+
+DiveCode.io is built using Next.js and uses Markdown files (stored in the `content/` directory) that include YAML frontmatter metadata. This metadata is essential for page generation, project linking (issue with label `project`), related content mapping, author attribution and overall site generation.
+
+Because the content is updated frequently, manually reviewing frontmatter metadata during code reviews has become both time-consuming and error-prone. Missing required fields, incorrect data types, or invalid links can slip through, potentially leading to runtime failures without providing clear feedback.
+
+To address these challenges, we need an automated validation mechanism. This tool should run both locally during development and as part of our CI/CD pipeline (for instance, on GitHub before merging pull requests), ensuring accurate metadata and reducing the likelihood of errors.
+
+## Problem Statement
+
+The goal is to implement a reliable and efficient `validateMarkdownFrontMatter` method in Typescript. Specifically, it should:
+
+1. Validate all required and optional fields according to a predefined schema
+2. Provide clear, actionable error messages
+3. Ensure type safety and consistency
+4. Be maintainable and extensible
+
+## Proposed Solution
+
+Several approaches for automatically validating the Markdown frontmatter were considered:
+
+### 1. Using AJV (Another JSON Schema Validator)
+
+Pros:
+
+- Mature and widely adopted with a robust ecosystem.
+- Leverages JSON Schema for clear and declarative definitions.
+- Excellent error reporting and support for complex validation (including custom formats).
+- Can automatically enforce strict validation rules (e.g., no additional properties).
+
+Cons:
+
+- Requires understanding of JSON Schema syntax.
+- Some learning curve for configuring custom formats (e.g., converting date strings to Date objects).
+
+### 2. Zod
+
+Pros:
+
+- TypeScript-first library with excellent integration, providing static type inference.
+- Intuitive API for many developers familiar with functional programming.
+- Clear error messages and composability.
+
+Cons:
+
+- Slightly less mature ecosystem compared to AJV.
+- Some limitations when working with highly complex validation logic or non-standard formats.
+
+#### 3. Custom Validation Code
+
+Pros:
+
+- Fully customizable and flexible.
+- No dependencies on external libraries.
+- Tailored error messages and control over the validation process.
+
+Cons:
+
+- Reinvents the wheel and increases maintenance burden.
+- Harder to scale as the complexity of metadata requirements grows.
+- Higher risk of introducing bugs in the validation logic.
+
+### Recommended Solution
+
+Using AJV with a well-defined JSON Schema to validate and parse Markdown frontmatter as it is easy to extend the schema as new fields and constraints arise, get clear and structured error messages, and set maintenable validation rules.
+
+## Implementation Plan
+
+- Define the JSON schema.
+- Implement the validator.
+- Write comprehensive tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "jest-environment-jsdom": "^29.7.0",
         "next": "15.1.6",
         "react": "^19.0.0",
@@ -741,6 +743,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.19.0",
@@ -2660,20 +2686,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -4674,6 +4716,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -4810,7 +4876,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4856,6 +4921,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.0",
@@ -6959,10 +7040,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8336,6 +8416,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "jest-environment-jsdom": "^29.7.0",
     "next": "15.1.6",
     "react": "^19.0.0",

--- a/types/frontmatter.ts
+++ b/types/frontmatter.ts
@@ -18,7 +18,7 @@ export type Frontmatter = {
      * from the `title` in the filename.
      * Optional. Default is `false`.
      */
-    allowTitleToDifferFromFilename?: boolean;
+    allowTitleToDifferFromFilename: boolean;
 
     /**
      * Date.
@@ -42,24 +42,24 @@ export type Frontmatter = {
      * Array of projects (array of `id` of `Project`).
      * Optional.
      */
-    projects?: string[];
+    projects: string[];
 
     /**
      * Array of skills (array of `id` of `Skill`).
      * Optional.
      */
-    skills?: string[];  // (array of `id` of `Skill`)
+    skills: string[];  // (array of `id` of `Skill`)
 
     /**
      * Array of links (e.g. /content/YYYY-MM-DD-test.md).
      * Optional.
      */
-    includeLinks?: string[];
+    includeLinks: string[];
 
     /**
      * Indicates whether all PRs that include the content file
      * should be listed.
      * Optional. Default is `true`.
      */
-    showRelatedPRs?: boolean;
+    showRelatedPRs: boolean;
 }

--- a/utils/parseMarkdownFrontmatter.ts
+++ b/utils/parseMarkdownFrontmatter.ts
@@ -14,7 +14,10 @@ addFormats(ajv);    // Add formats like data and uri
 const frontmatterSchema = {
     type: 'object',
     properties: {
-        title: { type: "string" },
+        title: {
+            type: 'string',
+            pattern: '\\S', // Ensures contains at least 1 non-whitespace character
+        },
         intro: { type: "string" },
         allowTitleToDifferFromFilename: { type: "boolean", default: false },
         date: { type: 'string', format: 'date' },
@@ -69,6 +72,11 @@ export function formatValidationError(error: ErrorObject): string {
         case 'minItems':
             message += `: Array must have at least ${error.params.limit} item(s)`;
             break;
+        case 'pattern':
+            if (error.instancePath === '/title') {
+                message += `: Title cannot be empty or contain only whitespace`;
+                break;
+            }
         default:
             message += ` (Keyword: ${error.keyword})`;
     }

--- a/utils/parseMarkdownFrontmatter.ts
+++ b/utils/parseMarkdownFrontmatter.ts
@@ -1,0 +1,105 @@
+// utils/parseMarkdownFrontmatter.ts
+
+import Ajv, { ErrorObject } from "ajv";
+import addFormats from "ajv-formats"
+import { Frontmatter } from "../types/frontmatter";
+
+const ajv = new Ajv({
+    allErrors: true,    // Report all validation errors, not just the first
+    strict: true,       // Prevent unknown keywords, restrict types...
+    useDefaults: true,  // Replace missing or undefined properties with defaults
+});
+addFormats(ajv);    // Add formats like data and uri
+
+const frontmatterSchema = {
+    type: 'object',
+    properties: {
+        title: { type: "string" },
+        intro: { type: "string" },
+        allowTitleToDifferFromFilename: { type: "boolean", default: false },
+        date: { type: 'string', format: 'date' },
+        authors: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 1,    // Ensure at least one author
+        },
+        featuredVideo: { type: 'string', format: 'uri' },
+        projects: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+        },
+        skills: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+        },
+        includeLinks: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+        },
+        showRelatedPRs: { type: 'boolean', default: true },
+    },
+    required: ['title', 'date', 'authors'],
+    additionalProperties: false, // Reject any unexpected field
+};
+
+const validateFrontmatter = ajv.compile<Frontmatter>(frontmatterSchema);
+
+/**
+ * Format a single Ajv error.
+ */
+export function formatValidationError(error: ErrorObject): string {
+    let message = `${error.instancePath} ${error.message}`;
+
+    switch (error.keyword) {
+        case 'required':
+            message += `: Missing required field '${error.params.missingProperty}'`;
+            break;
+        case 'type':
+            message += `: Expected type '${error.params.type}'`;
+            break;
+        case 'additionalProperties':
+            message += `: Unexpected field '${error.params.additionalProperty}'`;
+            break;
+        case 'format':
+            message += `: Invalid format '${error.params.format}'`;
+            break;
+        case 'minItems':
+            message += `: Array must have at least ${error.params.limit} item(s)`;
+            break;
+        default:
+            message += ` (Keyword: ${error.keyword})`;
+    }
+
+    return message;
+}
+
+export function parseMarkdownFrontmatter(data: unknown): Frontmatter {
+    if (!validateFrontmatter(data)) {
+        const errors = validateFrontmatter.errors || [];
+
+        const errorMessages = errors.map(formatValidationError);
+
+        throw new Error(`Frontmatter validation failed:\n${errorMessages.join('\n')}`);
+    }
+
+    const fm = data as Record<string, unknown>;
+
+    return {
+        title: fm.title as string,
+        intro: fm.intro as string | undefined,
+        allowTitleToDifferFromFilename:
+            fm.allowTitleToDifferFromFilename as boolean,
+        date: new Date(fm.date as string),
+        authors: fm.authors as [string, ...string[]],
+        featuredVideo: fm.featuredVideo
+            ? new URL(fm.featuredVideo as string)
+            : undefined,
+        projects: fm.projects as string[],
+        skills: fm.skills as string[],
+        includeLinks: fm.includeLinks as string[],  // TODO (108): enforce link formats
+        showRelatedPRs: fm.showRelatedPRs as boolean,
+    }
+}

--- a/utils/parseMarkdownFrontmatter.ts
+++ b/utils/parseMarkdownFrontmatter.ts
@@ -1,6 +1,6 @@
 // utils/parseMarkdownFrontmatter.ts
 
-import Ajv, { ErrorObject } from "ajv";
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 import addFormats from "ajv-formats"
 import { Frontmatter } from "../types/frontmatter";
 
@@ -51,7 +51,7 @@ const frontmatterSchema = {
 const validateFrontmatter = ajv.compile<Frontmatter>(frontmatterSchema);
 
 /**
- * Format a single Ajv error.
+ * Format a single validation error.
  */
 export function formatValidationError(error: ErrorObject): string {
     let message = `${error.instancePath} ${error.message}`;
@@ -84,12 +84,18 @@ export function formatValidationError(error: ErrorObject): string {
     return message;
 }
 
+/**
+ * Get formatted validation errors. 
+ */
+export function getValidationErrors(validator: ValidateFunction): string[] {
+    const errors = validateFrontmatter.errors || [];
+    return errors.map(formatValidationError);
+}
+
+
 export function parseMarkdownFrontmatter(data: unknown): Frontmatter {
     if (!validateFrontmatter(data)) {
-        const errors = validateFrontmatter.errors || [];
-
-        const errorMessages = errors.map(formatValidationError);
-
+        const errorMessages = getValidationErrors(validateFrontmatter);
         throw new Error(`Frontmatter validation failed:\n${errorMessages.join('\n')}`);
     }
 


### PR DESCRIPTION
closes #101.

Read the design document [here](https://github.com/ichilabs/divecode.io/blob/c102ce5dc3c4c640beaca893affeb16595eebebb/content/design-documents/2025-02-18-markdown-frontmatter-validator.md).

The frontmatter was defined here: #78.